### PR TITLE
Update DdpAccount.cs

### DIFF
--- a/unity-project/Assets/Moulin/DDP/account/DdpAccount.cs
+++ b/unity-project/Assets/Moulin/DDP/account/DdpAccount.cs
@@ -114,8 +114,13 @@ namespace Moulin.DDP {
 
 		public IEnumerator Logout() {
 			MethodCall logoutCall = connection.Call("logout");
-			yield return logoutCall.WaitForResult();
+			
+			if (logoutCall.error != null) {
+				throw new InvalidOperationException("Logout Error! Try Again!");
+			}
+			
 			HandleLogoutResult(logoutCall);
+			yield return logoutCall.WaitForResult();
 		}
 
 	}


### PR DESCRIPTION
Pull request to Tom Bruckner’s fork of unity3d-DDP-Client:

Hi there,

This pull request is being submitted in response to [github issue #11450](https://github.com/meteor/meteor/issues/11450) posted on meteor API repository. Also see [here](https://github.com/green-coder/unity3d-ddp-client/pull/11)

This pull request addresses this issue (in @derwaldgeist’s own words): " ...We also noticed that if we do call logout immediately before the login, the Meteor server won't always remove the login token from the database as it normally would..."

We figured that there are three possible reasons why the token may sometimes remain in the database of client server.

1. In case of Ddperror not being null, the tokens are not going to be deleted by [HandleLogoutResult](https://github.com/derwaldgeist/unity3d-ddp-client/blob/1dce71e7108b7aeb2867220e2a8991a4d6ced1c6/unity-project/Assets/Moulin/DDP/account/DdpAccount.cs#L72). Our proposed fix suggests that during ‘logout’ call the Ddperror throws warning to clients, asking them to retry logout.

2. [Meteor's ‘logout' call](https://github.com/meteor/meteor/blob/dae7af832d08a8b19384ac19aa5a5a9b6b005e55/packages/accounts-base/accounts_server.js#L659) first deletes the tokens and then calls other methods or ‘callback’ for running in Fibers. Our proposed fix suggests that unity3d-DDP-Client also deletes the tokens before starting to [WaitForResult](https://github.com/derwaldgeist/unity3d-ddp-client/blob/1dce71e7108b7aeb2867220e2a8991a4d6ced1c6/unity-project/Assets/Moulin/DDP/account/DdpAccount.cs#L117).

3. At [logout](https://github.com/derwaldgeist/unity3d-ddp-client/blob/1dce71e7108b7aeb2867220e2a8991a4d6ced1c6/unity-project/Assets/Moulin/DDP/account/DdpAccount.cs#L115), [OnWebSocketClose](https://github.com/green-coder/unity3d-ddp-client/blob/24371a04c9d5ff304e8071f05360522704278946/unity-project/Assets/Moulin/DDP/ddp/DdpConnection.cs#L180) process starts in main thread, and runs until finish OR until another process launches from [RunInMainThreadAfter](https://github.com/green-coder/unity3d-ddp-client/blob/24371a04c9d5ff304e8071f05360522704278946/unity-project/Assets/Moulin/DDP/util/CoroutineHelper.cs#L55https://github.com/green-coder/unity3d-ddp-client/blob/24371a04c9d5ff304e8071f05360522704278946/unity-project/Assets/Moulin/DDP/util/CoroutineHelper.cs) thread, depending on whether the time difference between [OnWebSocketClose](https://github.com/green-coder/unity3d-ddp-client/blob/24371a04c9d5ff304e8071f05360522704278946/unity-project/Assets/Moulin/DDP/ddp/DdpConnection.cs#L180) and [RunInMainThreadAfter](https://github.com/green-coder/unity3d-ddp-client/blob/24371a04c9d5ff304e8071f05360522704278946/unity-project/Assets/Moulin/DDP/util/CoroutineHelper.cs#L55https://github.com/green-coder/unity3d-ddp-client/blob/24371a04c9d5ff304e8071f05360522704278946/unity-project/Assets/Moulin/DDP/util/CoroutineHelper.cs) process is greater than the hard-coded delay value passed to [RunAfter](https://github.com/green-coder/unity3d-ddp-client/blob/24371a04c9d5ff304e8071f05360522704278946/unity-project/Assets/Moulin/DDP/util/CoroutineHelper.cs#L56). The delay value needs to be sufficiently large to make sure that the ‘logout’ related processes finish before ‘login’ is called. We consulted [meteor’s tested wait times](https://github.com/meteor/meteor/blob/e3ff09ef4464c1bda55155324c576036f52786e0/tools/tool-testing/test-utils.js#L39) before coming up with this suggestion.

Path: [unity3d-ddp-client](https://github.com/derwaldgeist/unity3d-ddp-client/tree/1dce71e7108b7aeb2867220e2a8991a4d6ced1c6)/[unityproject](https://github.com/derwaldgeist/unity3d-ddp-client/tree/1dce71e7108b7aeb2867220e2a8991a4d6ced1c6/unity-project)/[Assets](https://github.com/derwaldgeist/unity3d-ddp-client/tree/1dce71e7108b7aeb2867220e2a8991a4d6ced1c6/unity-project/Assets)/[Moulin](https://github.com/derwaldgeist/unity3d-ddp-client/tree/1dce71e7108b7aeb2867220e2a8991a4d6ced1c6/unity-project/Assets/Moulin)/[DDP](https://github.com/derwaldgeist/unity3d-ddp-client/tree/1dce71e7108b7aeb2867220e2a8991a4d6ced1c6/unity-project/Assets/Moulin/DDP)/[account](https://github.com/derwaldgeist/unity3d-ddp-client/tree/1dce71e7108b7aeb2867220e2a8991a4d6ced1c6/unity-project/Assets/Moulin/DDP/account)/DdpAccount.cs